### PR TITLE
Add RN type definition file to suppress ts warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-native": "^0.52.8",
     "ava": "^0.24.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-react-native": "^4.0.0",

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,5 +1,4 @@
 // persistent queue using AsyncStorage
-// @ts-ignore: Cannot find module
 import { AsyncStorage } from 'react-native'
 import * as uuid from 'react-native-uuid'
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,7 +1,6 @@
 import test from 'ava'
 import './_mock-async-storage'
 import Puree from '../'
-// @ts-ignore: Cannot find module
 import { AsyncStorage } from 'react-native'
 
 function addEventTime (log) {

--- a/src/test/queue.ts
+++ b/src/test/queue.ts
@@ -1,7 +1,6 @@
 import test from 'ava'
 import './_mock-async-storage'
 import Queue from '../queue'
-// @ts-ignore: Cannot find module
 import { AsyncStorage } from 'react-native'
 
 test.beforeEach(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,16 @@
   dependencies:
     arrify "^1.0.1"
 
+"@types/react-native@^0.52.8":
+  version "0.52.8"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.52.8.tgz#dd5aa7c4eb944d7c0b2b249a2bb811aa119f49c6"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.0.36"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.36.tgz#ceb5639013bdb92a94147883052e69bb2c22c69b"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"


### PR DESCRIPTION
## Overview

This PR adds `@types/react-native` to dev dependencies and the aim of it is to suppress `@ts-ignore: Cannot find module`.

Thx!