### PR TITLE
Print error as warning when retry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,13 +102,13 @@ export default class Puree {
   }
 
   private async process (logs: Log[], retryCount = 0): Promise<Error> {
-    if (retryCount > this.maxRetry) {
-      return new Error('retryCount exceeded max retry')
-    }
-
     try {
       await this.flushHandler(logs)
-    } catch {
+    } catch (e) {
+      if (retryCount >= this.maxRetry) {
+        return new Error('retryCount exceeded max retry')
+      }
+      console.warn(`Error occurred! Retrying... (retry count: ${retryCount})`, e);
       await wait(Math.pow(2, retryCount) * this.firstRetryInterval)
       return this.process(logs, retryCount + 1)
     }


### PR DESCRIPTION
Problem
===

Currently react-native-puree does not display the original error message of flushHandler, so debugging flushHandler is very hard.


Solution
===

Print the original error as warning message when retry.


example:

```
07-11 10:51:45.898 21633  6683 I ReactNativeJS: [puree] Flushing 1 logs                                                                                                                                                                                                                                                                          
07-11 10:51:46.008 21633  6683 W ReactNativeJS: 'Error occurred! Retrying... (retry count: 0)', { [Error: someerror}]
07-11 10:51:46.008 21633  6683 W ReactNativeJS:   line: 78963,                                                                                                                                                                                                  
07-11 10:51:46.008 21633  6683 W ReactNativeJS:   column: 99,
07-11 10:51:46.008 21633  6683 W ReactNativeJS:   sourceURL: 'http://10.0.2.2:8081/index.delta?platform=android&dev=true&minify=false' }                                                                                                                                      
07-11 10:51:47.036 21633  6683 W ReactNativeJS: 'Error occurred! Retrying... (retry count: 1)', { [Error: someerror}]
07-11 10:51:47.036 21633  6683 W ReactNativeJS:   line: 78963,                                                                                                                
07-11 10:51:47.036 21633  6683 W ReactNativeJS:   column: 99, 
07-11 10:51:47.036 21633  6683 W ReactNativeJS:   sourceURL: 'http://10.0.2.2:8081/index.delta?platform=android&dev=true&minify=false' }
07-11 10:51:49.068 21633  6683 W ReactNativeJS: 'Error occurred! Retrying... (retry count: 2)', { [Error: someerror}]
07-11 10:51:49.068 21633  6683 W ReactNativeJS:   line: 78963,                                                                                                                
07-11 10:51:49.068 21633  6683 W ReactNativeJS:   column: 99, 
07-11 10:51:49.068 21633  6683 W ReactNativeJS:   sourceURL: 'http://10.0.2.2:8081/index.delta?platform=android&dev=true&minify=false' }
07-11 10:51:53.091 21633  6683 W ReactNativeJS: 'Error occurred! Retrying... (retry count: 3)', { [Error: someerror}]
07-11 10:51:53.091 21633  6683 W ReactNativeJS:   line: 78963,                                                                                                                
07-11 10:51:53.091 21633  6683 W ReactNativeJS:   column: 99, 
07-11 10:51:53.091 21633  6683 W ReactNativeJS:   sourceURL: 'http://10.0.2.2:8081/index.delta?platform=android&dev=true&minify=false' }
07-11 10:52:01.304 21633  6683 W ReactNativeJS: 'Error occurred! Retrying... (retry count: 4)', { [Error: someerror}]
07-11 10:52:01.304 21633  6683 W ReactNativeJS:   line: 78963,                                                                                                                
07-11 10:52:01.304 21633  6683 W ReactNativeJS:   column: 99, 
07-11 10:52:01.304 21633  6683 W ReactNativeJS:   sourceURL: 'http://10.0.2.2:8081/index.delta?platform=android&dev=true&minify=false' }
07-11 10:52:17.402 21633  6683 E ReactNativeJS: [Error: retryCount exceeded max retry] 
```


Other changes
===

I also changed timing of `return new Error('retryCount exceeded max retry')`.
Currently it waits meaninglessly. So I moved the `return new Error(...)` to before waiting.



---


And can you invite me to this repository and collaborator of npmjs.com ?
I'd like to bump the version and publish to npm.